### PR TITLE
Contributing

### DIFF
--- a/.commitlintrc
+++ b/.commitlintrc
@@ -1,0 +1,3 @@
+{
+    extends: ['@commitlint/config-conventional']
+}

--- a/.github/workflows/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/workflows/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,18 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: 'bug'
+assignees: ''
+---
+
+## Bug description
+
+#### Description
+
+#### Expected outcome
+
+#### Actual outcome
+
+### Screenshots / Video / StackTrace
+

--- a/.github/workflows/ISSUE_TEMPLATE/feature.md
+++ b/.github/workflows/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,14 @@
+---
+name: Feature
+about: Suggest a feature proposal
+title: ''
+labels: 'feature'
+assignees: ''
+---
+
+## Feature description
+
+#### Description
+
+#### Expected outcome
+

--- a/.github/workflows/PULL_REQUEST_TEMPLATE.md
+++ b/.github/workflows/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+### Related to
+Issue #XXX
+
+### Notes
+Some notes about changes...
+
+### Types of changes
+-   [ ]   :sparkles: New feature
+-   [ ]   :recycle: Refactoring
+-   [ ]   :bug: Bug fix
+-   [ ]   :boom: Breaking change
+
+### Maintainability & Security
+-   [ ]   :check: contains tests
+
+
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,12 +10,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
       - uses: actions/setup-node@v3
         with:
           node-version: '16'
       - name: Install dependencies 📦
         run: yarn
+
+      - name: Run commitlint 📝
+        run: git log -1 --pretty=format:"%s" | yarn commitlint --verbose
+
       - name: Run linter 👁️
         run: yarn lint
+
       - name: Run tests 🧪
         run: yarn test

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx --no -- commitlint --edit 

--- a/.versionrc.json
+++ b/.versionrc.json
@@ -1,0 +1,14 @@
+{
+  "types": [
+    {"type": "feat", "section": "Features"},
+    {"type": "fix", "section": "Bug Fixes"},
+    {"type": "docs", "section": "Documentation"},
+    {"type": "ci", "hidden": true},
+    {"type": "chore", "hidden": true},
+    {"type": "refactor", "hidden": true},
+    {"type": "perf", "hidden": true},
+    {"type": "test", "hidden": true}
+  ],
+  "commitUrlFormat": "https://github.com/thomasbrodusch/piupiu/commits/{{hash}}",
+  "compareUrlFormat": "https://github.com/thomasbrodusch/piupiu/compare/{{previousTag}}...{{currentTag}}"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+## 0.2.0 (2022-12-26)
+
+
+### Features
+
+* add checkers functions ([3658e0f](https://github.com/thomasbrodusch/piupiu/commits/3658e0f266d0d1a5ebdabb5398c4a8a9dbd720ab))
+* add sanitizers functions ([0810bc5](https://github.com/thomasbrodusch/piupiu/commits/0810bc50cdb2d6efa08bffc6fd4c3d410fa6de82))
+* add sanitizers functions ([0e60dd1](https://github.com/thomasbrodusch/piupiu/commits/0e60dd1566c19cf1d4e150e347f59b67715b205d))
+* add stringSegmenter ([d250214](https://github.com/thomasbrodusch/piupiu/commits/d250214f4c84782b7bb75aa17e886cdefa72b24f))
+* add transformers functions ([3e2f308](https://github.com/thomasbrodusch/piupiu/commits/3e2f3080a9318e65b1e0a089b6dd20f22a8db9ae))
+* implements some randomizers and mocking factory ([3801381](https://github.com/thomasbrodusch/piupiu/commits/3801381c91d3136c94b0a7bf08fba68e06c91c50))
+* init docsify ([799da81](https://github.com/thomasbrodusch/piupiu/commits/799da81e250c86f1af41fe33bcd7386d6381ec14))
+
+
+### Documentation
+
+* add checkers documentation ([20dac93](https://github.com/thomasbrodusch/piupiu/commits/20dac931c9e0ecff4789caca7d49c87270044c8d))
+* add CODE_OF_CONDUCT.md ([787fdd0](https://github.com/thomasbrodusch/piupiu/commits/787fdd09d7ab55b24c4c74da47e7e4a7500029d0))
+* add CONTRIBUTING.md ([5f62c68](https://github.com/thomasbrodusch/piupiu/commits/5f62c683f7c9acccde0c708ba8fae6c5f659d44b))
+* add docsify coverpage, sidebar and quickstart doc ([a9a7e34](https://github.com/thomasbrodusch/piupiu/commits/a9a7e34546d4f0a6bdf5f94f791805b481ee5b9d))
+* add licence and README ([0c463c9](https://github.com/thomasbrodusch/piupiu/commits/0c463c9b582158d6423a64216f8f64350a6233a8))
+* add mocking documentation ([0ffc28e](https://github.com/thomasbrodusch/piupiu/commits/0ffc28e70af1a114e40d77e4ef49338756662340))
+* add randomizers documentation ([0960bc0](https://github.com/thomasbrodusch/piupiu/commits/0960bc064d5649e3ecb3c00569716e22948917c5))
+* add sanitizers documentation ([9feef3d](https://github.com/thomasbrodusch/piupiu/commits/9feef3d209a417ac51d37f95bf7f84adab3b2380))
+* add transformers documentation ([1782b1b](https://github.com/thomasbrodusch/piupiu/commits/1782b1b67b1f204550591a79a78cc5b06f461a38))
+* edit README.md ([f93dc24](https://github.com/thomasbrodusch/piupiu/commits/f93dc243ca378f12c0a1086b7fb37839f3e69c85))

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,134 @@
+
+# piupiu Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+brodusch.thomas+piupiu[at]gmail.com.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# Contributing
+
+When contributing to this repository, please first discuss the change you wish to make via issue,
+email, or any other method with the owners of this repository before making a change.
+
+Please note we have a [code of conduct](CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.
+
+## Commit
+All commit need to follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
+
+## Pull Request 
+
+1. Ensure that your feature is **fully tested** by adding new specs in [tests/](./tests).
+
+
+2. Update the documentation in [docs/](./docs) and [README.md](README.md) with details of changes to the project.
+
+
+3. Increase the version numbers in any examples files and the [README.md](README.md) to the new version that this
+   Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
+
+
+4. Your Pull Request will be merged in once you have the sign-off of one core contributor, or if you
+   do not have permission to do that, you may request the second reviewer to merge it for you.

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,5 +1,6 @@
 - Getting started
     - [Quick start](quickstart.md)
+    - [Changelog](https://github.com/thomasbrodusch/piupiu/blob/develop/CHANGELOG.md)
 
 - Mocking
   - [ MockFactory ](mocking/mock.factory.md)

--- a/package.json
+++ b/package.json
@@ -45,18 +45,25 @@
     "dist"
   ],
   "devDependencies": {
+    "@commitlint/cli": "^17.3.0",
+    "@commitlint/config-conventional": "^17.3.0",
     "@rollup/plugin-typescript": "^10.0.1",
     "@typescript-eslint/eslint-plugin": "^5.47.0",
     "@typescript-eslint/parser": "^5.47.0",
     "@vitest/coverage-c8": "^0.25.8",
     "docsify-cli": "^4.4.4",
     "eslint": "^8.30.0",
+    "husky": "^8.0.2",
     "prettier": "2.8.1",
     "rollup": "^3.7.5",
     "rollup-plugin-dts": "^5.1.0",
     "rollup-plugin-esbuild": "^5.0.0",
     "tslib": "^2.4.1",
     "typescript": "^4.9.4",
-    "vitest": "^0.25.8"
+    "vitest": "^0.26.2"
+  },
+  "gitHooks": {
+    "pre-commit": "yarn lint",
+    "commit-msg": ".git/COMMIT_EDITMSG | yarn commitlint --verbose"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,17 +12,21 @@
     "lint": "yarn eslint .",
     "test": "vitest --config vitest.config.ts",
     "coverage": "vitest run --coverage",
-    "preview-doc": "docsify serve docs"
+    "preview-doc": "docsify serve docs",
+    "release": "standard-version",
+    "release:minor": "standard-version --release-as minor",
+    "release:patch": "standard-version --release-as patch",
+    "release:major": "standard-version --release-as major"
   },
   "license": "MIT",
   "keywords": [
-    "functions",
-    "toolbox",
+    "library",
     "utils",
-    "validators",
+    "validator",
     "transformer",
     "sanitizer",
-    "helpers"
+    "randomizer",
+    "toolbox"
   ],
   "repository": {
     "type": "git",
@@ -58,6 +62,7 @@
     "rollup": "^3.7.5",
     "rollup-plugin-dts": "^5.1.0",
     "rollup-plugin-esbuild": "^5.0.0",
+    "standard-version": "^9.5.0",
     "tslib": "^2.4.1",
     "typescript": "^4.9.4",
     "vitest": "^0.26.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "piupiu",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "piupiu - JavaScript utilities functions that got your back",
   "author": {
     "name": "Thomas Brodusch",


### PR DESCRIPTION
Add `commitlint` to enforce commit convention (conventional comit)
* We use [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) for any of our commits description.